### PR TITLE
Add task priority feature

### DIFF
--- a/src/components/TodoItem.vue
+++ b/src/components/TodoItem.vue
@@ -2,6 +2,9 @@
   <li class="todo-item">
     <div class="todo-container">
       <div class="todo-text">
+        <div class="priority-icon" v-if="!todo.isSubtask" :title="todo.priority">
+          {{ getPriorityIcon(todo.priority) }}
+        </div>
         <span 
           v-if="!isEditing"
           :class="{ completed: todo.completed }"
@@ -15,6 +18,20 @@
         />
       </div>
       <div class="todo-actions">
+        <div v-if="!todo.isSubtask" class="priority-dropdown" v-click-outside="closePriorityDropdown">
+          <button class="priority-btn" @click="togglePriorityDropdown">⚑</button>
+          <div v-if="showPriorityDropdown" class="priority-menu">
+            <div
+              v-for="priority in priorities"
+              :key="priority"
+              class="priority-item"
+              @click="changePriority(priority)"
+              :class="{ active: todo.priority === priority }"
+            >
+              {{ getPriorityIcon(priority) }} {{ priority }}
+            </div>
+          </div>
+        </div>
         <button v-if="!isEditing" class="edit-btn" @click="startEdit">✎</button>
         <button 
           class="complete-btn" 
@@ -50,8 +67,25 @@ export default {
   data() {
     return {
       isEditing: false,
-      editText: ''
+      editText: '',
+      showPriorityDropdown: false,
+      priorities: ['Critical', 'High', 'Medium', 'Low']
     }
+  },
+  directives: {
+    clickOutside: {
+      mounted(el, binding) {
+        el._clickOutside = (event) => {
+          if (!(el === event.target || el.contains(event.target))) {
+            binding.value(event);
+          }
+        };
+        document.addEventListener('click', el._clickOutside);
+      },
+      unmounted(el) {
+        document.removeEventListener('click', el._clickOutside);
+      },
+    },
   },
   methods: {
     startEdit() {
@@ -67,6 +101,25 @@ export default {
     },
     toggleComplete() {
       this.$emit('toggle-complete');
+    },
+    getPriorityIcon(priority) {
+      switch (priority) {
+        case 'Critical': return '❗';
+        case 'High': return '⚡';
+        case 'Medium': return '⚑';
+        case 'Low': return '↓';
+        default: return '⚑';
+      }
+    },
+    togglePriorityDropdown() {
+      this.showPriorityDropdown = !this.showPriorityDropdown;
+    },
+    closePriorityDropdown() {
+      this.showPriorityDropdown = false;
+    },
+    changePriority(priority) {
+      this.$emit('change-priority', priority);
+      this.showPriorityDropdown = false;
     }
   }
 }
@@ -148,5 +201,62 @@ export default {
 
 .add-subtask-btn:hover {
   color: #3aa876;
+}
+
+.todo-text {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.priority-icon {
+  font-size: 16px;
+  min-width: 20px;
+}
+
+.priority-dropdown {
+  position: relative;
+}
+
+.priority-btn {
+  background-color: transparent;
+  border: none;
+  font-size: 20px;
+  cursor: pointer;
+  padding: 0 8px;
+  color: #42b983;
+}
+
+.priority-btn:hover {
+  color: #3aa876;
+}
+
+.priority-menu {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  background-color: white;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  z-index: 1000;
+  min-width: 120px;
+}
+
+.priority-item {
+  padding: 8px 12px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.priority-item:hover {
+  background-color: #f5f5f5;
+}
+
+.priority-item.active {
+  background-color: #e8f5e9;
+  color: #42b983;
 }
 </style>

--- a/src/components/TodoItem.vue
+++ b/src/components/TodoItem.vue
@@ -28,7 +28,8 @@
               @click="changePriority(priority)"
               :class="{ active: todo.priority === priority }"
             >
-              {{ getPriorityIcon(priority) }} {{ priority }}
+              <span class="priority-icon">{{ getPriorityIcon(priority) }}</span>
+              <span>{{ priority }}</span>
             </div>
           </div>
         </div>
@@ -105,10 +106,10 @@ export default {
     getPriorityIcon(priority) {
       switch (priority) {
         case 'Critical': return '❗';
-        case 'High': return '⚡';
-        case 'Medium': return '⚑';
+        case 'High': return '↑';
+        case 'Medium': return '−';
         case 'Low': return '↓';
-        default: return '⚑';
+        default: return '−';
       }
     },
     togglePriorityDropdown() {
@@ -211,9 +212,10 @@ export default {
 
 .priority-icon {
   font-size: 14px;
-  min-width: 16px;
+  width: 16px;
   display: inline-block;
   text-align: center;
+  line-height: 1;
 }
 
 .priority-dropdown {
@@ -248,9 +250,9 @@ export default {
 .priority-item {
   padding: 8px 12px;
   cursor: pointer;
-  display: flex;
+  display: grid;
+  grid-template-columns: 24px 1fr;
   align-items: center;
-  gap: 8px;
   font-size: 0.9em;
   min-width: 110px;
 }

--- a/src/components/TodoItem.vue
+++ b/src/components/TodoItem.vue
@@ -210,8 +210,10 @@ export default {
 }
 
 .priority-icon {
-  font-size: 16px;
-  min-width: 20px;
+  font-size: 14px;
+  min-width: 16px;
+  display: inline-block;
+  text-align: center;
 }
 
 .priority-dropdown {
@@ -249,6 +251,8 @@ export default {
   display: flex;
   align-items: center;
   gap: 8px;
+  font-size: 0.9em;
+  min-width: 110px;
 }
 
 .priority-item:hover {

--- a/src/components/TodoList.vue
+++ b/src/components/TodoList.vue
@@ -21,6 +21,7 @@
         @delete-subtask="(subtaskId) => showDeleteSubtaskConfirmation(todo.id, subtaskId)"
         @edit-subtask="(subtaskId, text) => handleEditSubtask(todo.id, subtaskId, text)"
         @toggle-subtask-complete="(subtaskId) => handleToggleSubtaskComplete(todo.id, subtaskId)"
+        @change-priority="(priority) => handleChangePriority(todo.id, priority)"
       />
     </ul>
     
@@ -77,6 +78,7 @@ export default {
       'deleteSubtask',
       'editSubtask',
       'toggleSubtaskComplete',
+      'changePriority',
       'clearTodos',
       'loadTodos',
       'saveTodos'
@@ -163,14 +165,18 @@ export default {
       this.toggleSubtaskComplete({ parentId, subtaskId });
       this.saveTodos();
     },
+    handleChangePriority(todoId, priority) {
+      this.changePriority({ todoId, priority });
+      this.saveTodos();
+    },
     exportToCsv() {
-      const headers = 'Task,Status\n';
+      const headers = 'Task,Status,Priority\n';
       const rows = this.todos.map(todo => {
         const status = todo.completed ? 'Completed' : 'Pending';
         const escapedText = todo.text.includes('"') ? 
           `"${todo.text.replace(/"/g, '""')}"` : 
           todo.text.includes(',') ? `"${todo.text}"` : todo.text;
-        let row = `${escapedText},${status}`;
+        let row = `${escapedText},${status},${todo.priority}`;
 
         if (todo.subtasks && todo.subtasks.length > 0) {
           todo.subtasks.forEach(subtask => {
@@ -178,7 +184,7 @@ export default {
             const escapedSubText = subtask.text.includes('"') ? 
               `"${subtask.text.replace(/"/g, '""')}"` : 
               subtask.text.includes(',') ? `"${subtask.text}"` : subtask.text;
-            row += `\n  - ${escapedSubText},${subStatus}`;
+            row += `\n  - ${escapedSubText},${subStatus},-`;
           });
         }
         return row;

--- a/src/models/Todo.js
+++ b/src/models/Todo.js
@@ -5,6 +5,7 @@ export class Todo {
     this.completed = false;
     this.isSubtask = isSubtask;
     this.subtasks = isSubtask ? null : [];
+    this.priority = isSubtask ? null : 'Medium';  // Default priority for main tasks
   }
 
   addSubtask(text) {
@@ -38,6 +39,7 @@ export class Todo {
       text: this.text,
       completed: this.completed,
       isSubtask: this.isSubtask,
+      priority: this.priority,
       subtasks: this.subtasks?.map(subtask => subtask.toJSON()) || null
     };
   }
@@ -46,9 +48,20 @@ export class Todo {
     const todo = new Todo(json.text, json.isSubtask);
     todo.id = json.id;
     todo.completed = json.completed;
+    todo.priority = json.priority;
     if (json.subtasks) {
       todo.subtasks = json.subtasks.map(subtaskJson => Todo.fromJSON(subtaskJson));
     }
     return todo;
+  }
+
+  setPriority(priority) {
+    if (this.isSubtask) {
+      throw new Error('Subtasks cannot have priority');
+    }
+    if (!['Critical', 'High', 'Medium', 'Low'].includes(priority)) {
+      throw new Error('Invalid priority level');
+    }
+    this.priority = priority;
   }
 }

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -62,6 +62,12 @@ export default createStore({
     },
     SET_TODOS(state, todos) {
       state.todos = todos;
+    },
+    CHANGE_PRIORITY(state, { todoId, priority }) {
+      const todo = state.todos.find(todo => todo.id === todoId);
+      if (todo) {
+        todo.setPriority(priority);
+      }
     }
   },
   actions: {
@@ -123,6 +129,9 @@ export default createStore({
     },
     saveTodos({ state }) {
       localStorage.setItem('todos', JSON.stringify(state.todos));
+    },
+    changePriority({ commit }, { todoId, priority }) {
+      commit('CHANGE_PRIORITY', { todoId, priority });
     }
   }
 });


### PR DESCRIPTION
This PR adds a priority feature to the TODO app with the following changes:

- Add priority levels (Critical/High/Medium/Low) to main tasks
- Add priority icons (❗↑−↓) with dropdown selector
- Include priority in CSV export
- Style improvements for better alignment and visual hierarchy
- Persist priority across page reloads

Priority is only available for main tasks, not subtasks.