### PR TITLE
Add list deletion functionality and fix button colors

### DIFF
--- a/src/components/LandingPage.vue
+++ b/src/components/LandingPage.vue
@@ -24,7 +24,10 @@
           class="list-card"
           @click="openList(list.id)"
         >
-          <h3>{{ list.name }}</h3>
+          <div class="list-header">
+            <h3>{{ list.name }}</h3>
+            <button class="delete-btn" @click.stop="confirmDeleteList(list)">×</button>
+          </div>
           <p>{{ list.todos.length }} items</p>
           <p class="last-modified">Last modified: {{ formatDate(list.lastModified) }}</p>
         </div>
@@ -80,12 +83,19 @@ export default {
       return new Date(date).toLocaleString();
     };
 
+    const confirmDeleteList = (list) => {
+      if (confirm(`Are you sure you want to delete the list "${list.name}"?`)) {
+        store.commit('deleteTodoList', list.id);
+      }
+    };
+
     return {
       newListName,
       todoLists,
       createList,
       openList,
-      formatDate
+      formatDate,
+      confirmDeleteList
     };
   }
 };
@@ -159,9 +169,30 @@ button:disabled {
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
 }
 
+.list-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 10px;
+}
+
 .list-card h3 {
-  margin: 0 0 10px 0;
+  margin: 0;
   color: #2c3e50;
+}
+
+.delete-btn {
+  background-color: transparent;
+  color: #ff4444;
+  border: none;
+  font-size: 24px;
+  cursor: pointer;
+  padding: 0 8px;
+  line-height: 1;
+}
+
+.delete-btn:hover {
+  color: #cc0000;
 }
 
 .list-card p {

--- a/src/components/TodoItem.vue
+++ b/src/components/TodoItem.vue
@@ -189,20 +189,26 @@ export default {
   color: #42b983;
 }
 
-.delete-btn {
+.todo-container .todo-item .delete-btn,
+.todo-container .subtask-item .delete-btn {
   color: #ff0000 !important;
+  border-color: #ff0000 !important;
 }
 
-.delete-btn:hover {
-  color: #cc0000 !important;
+.todo-container .todo-item .delete-btn:hover,
+.todo-container .subtask-item .delete-btn:hover {
+  color: #ffffff !important;
+  background-color: #ff0000 !important;
 }
 
-.add-subtask-btn {
+.todo-container .todo-item .add-subtask-btn {
   color: #00aa00 !important;
+  border-color: #00aa00 !important;
 }
 
-.add-subtask-btn:hover {
-  color: #008800 !important;
+.todo-container .todo-item .add-subtask-btn:hover {
+  color: #ffffff !important;
+  background-color: #00aa00 !important;
 }
 
 .todo-text {

--- a/src/components/TodoItem.vue
+++ b/src/components/TodoItem.vue
@@ -170,6 +170,7 @@ export default {
   font-size: 20px;
   cursor: pointer;
   padding: 0 8px;
+  transition: color 0.2s;
 }
 
 .edit-btn {
@@ -189,19 +190,19 @@ export default {
 }
 
 .delete-btn {
-  color: #ff4444;
+  color: #ff0000 !important;
 }
 
 .delete-btn:hover {
-  color: #cc0000;
+  color: #cc0000 !important;
 }
 
 .add-subtask-btn {
-  color: #42b983;
+  color: #00aa00 !important;
 }
 
 .add-subtask-btn:hover {
-  color: #3aa876;
+  color: #008800 !important;
 }
 
 .todo-text {

--- a/src/components/TodoItem.vue
+++ b/src/components/TodoItem.vue
@@ -173,11 +173,11 @@ export default {
 }
 
 .edit-btn {
-  color: #42b983;
+  color: #888;
 }
 
 .edit-btn:hover {
-  color: #3aa876;
+  color: #666;
 }
 
 .complete-btn {

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -57,6 +57,13 @@ export default createStore({
     },
     setTodoLists(state, lists) {
       state.todoLists = lists;
+    },
+    deleteTodoList(state, listId) {
+      const index = state.todoLists.findIndex(list => list.id === listId);
+      if (index > -1) {
+        state.todoLists.splice(index, 1);
+        localStorage.setItem('todoLists', JSON.stringify(state.todoLists));
+      }
     }
   },
   actions: {


### PR DESCRIPTION
This PR adds the following changes:

1. Add delete button to todo lists:
   - Red delete button (×) in top-right of each list card
   - Confirmation dialog before deletion
   - Deletes list from state and localStorage

2. Attempted to fix todo item button colors (not working yet)

The list deletion feature provides a better way to manage todo lists by allowing users to remove unwanted lists with a confirmation step to prevent accidental deletions.