### PR TITLE
Add rowboat microagent with 'rowrow' trigger

### DIFF
--- a/.openhands/microagents/rowboat.md
+++ b/.openhands/microagents/rowboat.md
@@ -1,0 +1,20 @@
+---
+name: rowboat
+type: knowledge
+version: 1.0.0
+agent: CodeActAgent
+triggers:
+  - rowrow
+---
+
+# Rowboat Microagent
+
+This microagent is triggered by the word "rowrow" and provides a simple response.
+
+## Instructions
+
+When triggered, please say "row your boat".
+
+## Usage
+
+This microagent activates when the trigger word "rowrow" is mentioned in the conversation and responds with the phrase "row your boat".


### PR DESCRIPTION
## Description

This PR adds a new microagent called "rowboat" to the `.openhands/microagents/` directory.

## Changes Made

- Created `rowboat.md` microagent file in `.openhands/microagents/`
- Added proper YAML frontmatter with metadata (name, type, version, agent, triggers)
- Configured the microagent to respond with "row your boat" when triggered by the word "rowrow"

## Microagent Details

- **Name**: rowboat
- **Type**: knowledge
- **Version**: 1.0.0
- **Agent**: CodeActAgent
- **Trigger**: rowrow
- **Response**: "row your boat"

## Testing

The microagent can be tested by using the trigger word "rowrow" in a conversation, which should activate the microagent and respond with "row your boat".

Co-authored-by: openhands <openhands@all-hands.dev>

@mamoodi can click here to [continue refining the PR](https://hieptl-all-2797.staging.all-hands.dev/conversations/4bf22a55b96345a2b42e9ab8cab81455)