### PR TITLE
Update rowboat microagent to include ASCII art

### DIFF
--- a/.openhands/microagents/rowboat.md
+++ b/.openhands/microagents/rowboat.md
@@ -13,8 +13,8 @@ This microagent is triggered by the word "rowrow" and provides a simple response
 
 ## Instructions
 
-When triggered, please say "row your boat".
+When triggered, please say "row your boat"....and then draw an ascii art.
 
 ## Usage
 
-This microagent activates when the trigger word "rowrow" is mentioned in the conversation and responds with the phrase "row your boat".
+This microagent activates when the trigger word "rowrow" is mentioned in the conversation and responds with the phrase "row your boat" followed by ASCII art of a boat.


### PR DESCRIPTION
## Summary

This PR updates the rowboat microagent to enhance its functionality by adding ASCII art output when triggered.

## Changes Made

- Updated `.openhands/microagents/rowboat.md` with new instructions
- Modified the microagent to say "row your boat" and then draw ASCII art
- Maintained the existing trigger word "rowrow"
- Enhanced user experience with visual output

## Testing

The microagent should now:
1. Respond to the trigger "rowrow"
2. Say "row your boat"
3. Display ASCII art of a boat

## Type of Change

- [x] Enhancement to existing microagent functionality
- [x] Documentation update

## Additional Notes

This update follows the specified requirements to enhance the rowboat microagent with ASCII art capabilities while maintaining backward compatibility with the existing trigger mechanism.

@mamoodi can click here to [continue refining the PR](https://hieptl-all-2797.staging.all-hands.dev/conversations/029da84957ae44b198527505f8b7e78b)